### PR TITLE
vue-gtagの追加

### DIFF
--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
+import VueGtag from 'vue-gtag'
 import store from '@/store/index'
 
 import DefaultLayout from '@/layout/default'
@@ -150,6 +151,16 @@ const router = new VueRouter({
   mode: 'history',
   routes,
 })
+
+if (process.env.NODE_ENV === 'production') {
+  Vue.use(
+    VueGtag,
+    {
+      config: { id: 'G-0HN4DDBSEZ' },
+    },
+    router
+  )
+}
 
 router.beforeEach((to, from, next) => {
   store.dispatch('users/getAuthUser')

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,8 +1,7 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-0HN4DDBSEZ"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-0HN4DDBSEZ');
+  window.dataLayer = window.dataLayer || []
+  function gtag(){ dataLayer.push(arguments) }
+  gtag('js', new Date())
+  gtag('config', 'G-0HN4DDBSEZ')
 </script>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "turbolinks": "^5.2.0",
     "vee-validate": "^3.4.13",
     "vue": "^2.6.14",
+    "vue-gtag": "^1.16.1",
     "vue-i18n": "^8",
     "vue-loader": "^15.9.8",
     "vue-router": "^3.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9664,6 +9664,11 @@ vue-eslint-parser@^8.0.1:
     lodash "^4.17.21"
     semver "^7.3.5"
 
+vue-gtag@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/vue-gtag/-/vue-gtag-1.16.1.tgz#edb2f20ab4f6c4d4d372dfecf8c1fcc8ab890181"
+  integrity sha512-5vs0pSGxdqrfXqN1Qwt0ZFXG0iTYjRMu/saddc7QIC5yp+DKgjWQRpGYVa7Pq+KbThxwzzMfo0sGi7ISa6NowA==
+
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"


### PR DESCRIPTION
SPAのためPVの測定が正しくできていなかった。
フロントのルーティング毎にPVを測定するためにvue-gtagを導入した。